### PR TITLE
Support homebrewed pow installation

### DIFF
--- a/libexec/powprox-print-pow-config
+++ b/libexec/powprox-print-pow-config
@@ -1,3 +1,7 @@
 #!/usr/bin/env bash
 pow_bin="$HOME/Library/Application Support/Pow/Current/bin"
-exec "$pow_bin/node" "$pow_bin/pow" --print-config
+if [ -d "$pow_bin" ]; then
+  exec "$pow_bin/node" "$pow_bin/pow" --print-config
+else
+  exec pow --print-config
+fi


### PR DESCRIPTION
Currently powprox won't start if pow is installed through homebrew. It fails with error like this:

```
libexec/powprox-generate-nginx-config:16:in `fetch': key not found: "POW_HTTP_PORT" (KeyError)
```

This PR adds support for homebrew-installed pow which has standalone executable file in `/usr/local/bin`.
