### PR TITLE
Leave Pow untouched. Serve TLS and SPDY only.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Powprox: Nginx proxy for Pow apps
 
 * Serve Pow apps with SSL and SPDY
+* Doesn't muck with your Pow setup at all. Only port 443 is proxied, not port 80.
 * No certificate mismatch errors in the browser
 * Automatically manage SSL certs
 * Optional per-app nginx config

--- a/libexec/powprox-setup
+++ b/libexec/powprox-setup
@@ -5,7 +5,7 @@
 # It'll install Nginx (if it isn't already), set up Pow proxy config
 # (if it isn't already, etc…), create a root certificate authority,
 # trust it in the Keychain, generate an SSL cert for all Pow domains,
-# and configure Nginx to run as root (to bind privileged ports 80 & 443).
+# and configure Nginx to run as root (to bind privileged port 443).
 set -e
 [ -n "$POWPROX_DEBUG" ] && set -x
 
@@ -98,11 +98,14 @@ nginx_launchdaemon() {
 }
 
 nginx_selftest() {
-  echo -n "Pow: "
-  curl -H host:pow http://127.0.0.1:20559/status.json
+  echo -n "Pow upstream: "
+  curl -H host:pow http://localhost:20559/status.json
   echo
-  echo -n "Nginx: "
-  curl -H host:pow http://127.0.0.1/status.json
+  echo -n "Pow with pf port forward: "
+  curl -H host:pow http://localhost:80/status.json
+  echo
+  echo -n "Nginx TLS proxy: "
+  curl -H host:pow --insecure https://localhost:443/status.json
   echo
 }
 
@@ -125,14 +128,6 @@ else
   echo "not installed with SPDY support."
   install_nginx
 fi
-
-echo "Removing Pow's port-forwarding rule"
-if [ -f /Library/LaunchDaemons/cx.pow.firewall.plist ]; then
-  sudo launchctl unload -w /Library/LaunchDaemons/cx.pow.firewall.plist >/dev/null 2>&1
-  sudo rm /Library/LaunchDaemons/cx.pow.firewall.plist
-  sudo pfctl -a 'com.apple/250.PowFirewall' -F nat
-fi
-
 generate_nginx_config
 
 echo "Launching Nginx"

--- a/share/powprox/nginx.conf.erb
+++ b/share/powprox/nginx.conf.erb
@@ -70,7 +70,6 @@ http {
 
   # Default server proxies all domains to Pow
   server {
-    listen 80 default_server;
     listen 443 ssl spdy default_server;
     server_name <%= pow_domains.map { |domain| "~^(?<pow_host>.+)\.#{domain}$" } * ' ' %> ~^(?<pow_host>.+)(\.\d+)\{4\}\.xip\.io$;
 


### PR DESCRIPTION
Make Powprox easy to try out and turn off without affecting your existing Pow setup.
- Only proxy port 443. Don't listen on port 80.
- Don't remove Pow's LaunchDaemon that sets up port-80 forwarding.
