### PR TITLE
Add enough X's to temp file template string per issue #8

### DIFF
--- a/libexec/generate-nginxreloader-launchdaemon
+++ b/libexec/generate-nginxreloader-launchdaemon
@@ -3,7 +3,7 @@
 set -e
 [ -n "$POWPROX_DEBUG" ] && set -x
 
-plist="$(mktemp -t generate-nginxreloader-launchdaemon).plist"
+plist="$(mktemp -t generate-nginxreloader-launchdaemon-XXX).plist"
 
 defaults write "$plist" Label com.basecamp.powprox.nginxreloader.plist
 defaults write "$plist" ProgramArguments -array "$(which nginx)" -s reload


### PR DESCRIPTION
mktemp complains about there not being any X's in the template string used for the nginxreloader plist file name. This PR resolves it by adding not just one, but three, X's.

This resolves [issue 8](https://github.com/basecamp/powprox/issues/8)